### PR TITLE
Mailer フォロー通知メール実装＆Letter Opener導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,8 @@ group :development do
   gem 'pry-byebug'
   gem 'rubocop-rails'
   gem 'web-console'
+  gem 'letter_opener'
+  gem 'letter_opener_web', '~> 3.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,8 @@ GEM
       xpath (~> 3.2)
     case_transform (0.2)
       activesupport
+    childprocess (5.1.0)
+      logger (~> 1.5)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
@@ -208,6 +210,17 @@ GEM
     json (2.12.2)
     jsonapi-renderer (0.2.2)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -453,6 +466,8 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   jsbundling-rails
+  letter_opener
+  letter_opener_web (~> 3.0)
   pg (>= 0.18, < 2.0)
   pry-byebug
   psych (~> 3.1)

--- a/app/mailers/relationship_mailer.rb
+++ b/app/mailers/relationship_mailer.rb
@@ -1,0 +1,7 @@
+class RelationshipMailer < ApplicationMailer
+  def new_follower(user, follower)
+    @user = user
+    @follower = follower
+    mail to: user.email, subject: '【お知らせ】フォローされました'
+  end
+end

--- a/app/mailers/relationshipmailer.rb
+++ b/app/mailers/relationshipmailer.rb
@@ -1,0 +1,2 @@
+class RelationshipMailer < ApplicationMailer
+end

--- a/app/mailers/relationshipmailer.rb
+++ b/app/mailers/relationshipmailer.rb
@@ -1,2 +1,0 @@
-class RelationshipMailer < ApplicationMailer
-end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -21,4 +21,11 @@
 class Relationship < ApplicationRecord
   belongs_to :follower, class_name: 'User'
   belongs_to :following, class_name: 'User'
+
+  after_create :send_email
+
+  private
+  def send_email
+    RelationshipMailer.new_follower(following, follower).deliver_now
+  end
 end

--- a/app/views/relationship_mailer/new_follower.html.haml
+++ b/app/views/relationship_mailer/new_follower.html.haml
@@ -1,0 +1,4 @@
+%p #{@user.email} さん
+%p 以下のユーザにフォローされました。
+
+= link_to 'プロフィールを確認する', account_url(@follower)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,6 +42,8 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.perform_deliveries = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
+  
   devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   root to: 'articles#index'


### PR DESCRIPTION
•	RelationshipMailer を追加し、new_follower メールを実装。メールビュー（HAML）も作成。  ￼
•	命名規則を修正（relationshipmailer.rb → relationship_mailer.rb）。  ￼
•	フォロー作成後に通知メールを送る after_create コールバックを Relationship に追加。  ￼
•	開発環境に letter_opener／letter_opener_web を導入（Gem 追加、delivery_method 設定、有効化）。  ￼
•	/letter_opener を routes にマウント（開発環境プレビュー用）。  ￼
•	メール本文にフォロワーのプロフィールへのリンクを追加。