### PR TITLE
Request Spec整備：ArticlesのCRUD入口とAPI(Comments)のリクエストテスト追加

### DIFF
--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :comment do
+    content { Faker::Lorem.characters(number: 300) }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,4 +72,5 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include FactoryBot::Syntax::Methods
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/requests/api/comments_spec.rb
+++ b/spec/requests/api/comments_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::Comments', type: :request do
+  let!(:user) { create(:user) }
+  let!(:article) { create(:article, user: user) }
+  let!(:comments) { create_list(:comment, 3, article: article) }
+
+  describe 'GET /api/comments' do
+    it '200 Status' do
+      get api_comments_path(article_id: article.id)
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/requests/api/comments_spec.rb
+++ b/spec/requests/api/comments_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe 'Api::Comments', type: :request do
     it '200 Status' do
       get api_comments_path(article_id: article.id)
       expect(response).to have_http_status(200)
+
+      body = JSON.parse(response.body)
+      expect(body.length).to eq 3
+      expect(body[0]['content']).to eq comments.first.content
+      expect(body[1]['content']).to eq comments.second.content
+      expect(body[2]['content']).to eq comments.third.content
     end
   end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -10,4 +10,20 @@ RSpec.describe 'Articles', type: :request do
       expect(response).to have_http_status(200)
     end
   end
+
+  describe 'POST /articles' do
+    context 'ログインしている場合' do
+      before do
+        sign_in user
+      end
+
+      it '記事が保存される' do
+        article_params = attributes_for(:article)
+        post articles_path({article: article_params})
+        expect(response).to have_http_status(302)
+        expect(Article.last.title).to eq(article_params[:title])
+        expect(Article.last.content.body.to_plain_text).to eq(article_params[:content])
+      end
+    end
+  end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Articles', type: :request do
+  let!(:user) { create(:user) }
+  let!(:article) { create_list(:article, 3, user: user) }
+
   describe 'GET /articles' do
     it '200ステータスが返ってくる' do
       get articles_path

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -25,5 +25,13 @@ RSpec.describe 'Articles', type: :request do
         expect(Article.last.content.body.to_plain_text).to eq(article_params[:content])
       end
     end
+
+    context 'ログインしていない場合' do
+      it 'ログイン画面に遷移する' do
+        article_params = attributes_for(:article)
+        post articles_path({article: article_params})
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
   end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe 'Articles', type: :request do
+  describe 'GET /articles' do
+    it '200ステータスが返ってくる' do
+      get articles_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end


### PR DESCRIPTION
•	spec/requests/articles_spec.rb を新規作成（GET /articles の200確認）。  ￼
•	FactoryBotで user/article を用意して一覧の前提データを生成。  ￼
•	rails_helper に Devise::Test::IntegrationHelpers を読み込み（request用）。  ￼
•	サインイン時の POST /articles：作成成功・302リダイレクト・本文保存を検証。  ￼
•	未ログイン時の POST /articles：ログイン画面へのリダイレクトを検証。  ￼
•	API用 spec/requests/api/comments_spec.rb を追加し、コメント一覧の200確認。  ￼
•	spec/factories/comments.rb を追加（300文字の本文を生成）。  ￼
•	APIレスポンスのJSONを解析し、件数と各 content が期待順で返ることを検証。