### PR TITLE
System Spec整備：記事一覧・詳細・プロフィールのE2Eテスト追加（Deviseヘルパ対応）

### DIFF
--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :profile do
+    nickname { Faker::Name.name }
+    introduction { Faker::Lorem.characters(number: 100) }
+    gender { Profile.genders.keys.sample }
+    birthday { Faker::Date.birthday(min_age: 18, max_age: 65) }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,5 +2,11 @@ FactoryBot.define do
   factory :user do
     email { Faker::Internet.email }
     password { 'password' }
+
+    trait :with_profile do
+      after :build do |user|
+        build(:profile, user: user)
+      end
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,4 +73,5 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
   config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Devise::Test::IntegrationHelpers, type: :system
 end

--- a/spec/system/article_spec.rb
+++ b/spec/system/article_spec.rb
@@ -10,4 +10,14 @@ RSpec.describe 'Article', type: :system do
       expect(page).to have_css('.card_title', text: article.title)
     end
   end
+
+  it '記事の詳細を表示できる' do
+    visit root_path
+
+    article = articles.first
+    click_on article.title
+
+    expect(page).to have_css('.article_title', text: article.title)
+    expect(page).to have_css('.article_content', text: article.content.to_plain_text)
+  end
 end

--- a/spec/system/article_spec.rb
+++ b/spec/system/article_spec.rb
@@ -1,7 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe 'Article', type: :system do
+  let!(:user) { create(:user) }
+  let!(:articles) { create_list(:article, 3, user: user) }
+
   it '記事一覧が表示される' do
     visit root_path
+    articles.each do |article|
+      expect(page).to have_content(article.title)
+    end
   end
 end

--- a/spec/system/article_spec.rb
+++ b/spec/system/article_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Article', type: :system do
   it '記事一覧が表示される' do
     visit root_path
     articles.each do |article|
-      expect(page).to have_content(article.title)
+      expect(page).to have_css('.card_title', text: article.title)
     end
   end
 end

--- a/spec/system/article_spec.rb
+++ b/spec/system/article_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe 'Article', type: :system do
+  it '記事一覧が表示される' do
+    visit root_path
+  end
+end

--- a/spec/system/profile_spec.rb
+++ b/spec/system/profile_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'Profile', type: :system do
+  let!(:user) { create(:user, :with_profile) }
+
+  context 'ログインしている場合' do
+    before do
+      sign_in user
+    end
+
+    it '自分のプロフィールを確認できる' do
+      visit profile_path
+      expect(page).to have_css('.profilePage_user_displayName',text: user.profile.nickname)
+    end
+  end
+end


### PR DESCRIPTION
•	System Specの土台を作成（spec/system/article_spec.rb を新規追加）。  ￼
•	記事一覧の表示テストを実装：FactoryBotでダミー記事を create_list 
　　タイトルが並ぶことを検証。選択子は .card_title を使用。  ￼
•	記事詳細の表示テストを追加：一覧からタイトルをクリックし、.article_title／.article_content の内容を検証。  ￼
•	Deviseの IntegrationHelpers を system spec で使えるように rails_helper.rb に include。  ￼
•	Profile用のFactoryを追加し、User に :with_profile トレイト（after :build で関連プロフィール生成）を定義。  ￼
•	プロフィール画面のSystem Specを追加：ログイン後に profile_path へ遷移
　　.profilePage_user_displayName にニックネームが表示されることを検証。